### PR TITLE
Fix rp_handler.py

### DIFF
--- a/rp_handler.py
+++ b/rp_handler.py
@@ -15,7 +15,7 @@ def _blocking_diarize(path: str):
     print("Diarizing audio file")
     return _pipeline.diarize(path)
 
-async def _handler_async(event):
+async def handler(event):
     # pull out the URL
     path = event.get("input", {}).get("url")
 
@@ -26,10 +26,6 @@ async def _handler_async(event):
     print("Diarization complete")
     print(result)
     return result
-
-def handler(event):
-    # wrap our async logic so runpod.serverless.start can call it synchronously
-    return asyncio.run(_handler_async(event))
 
 # Start the Serverless function when the script is run
 if __name__ == '__main__':


### PR DESCRIPTION
"{"error_type": "<class 'RuntimeError'>", "error_message": "asyncio.run() cannot be called from a running event loop", "error_traceback": "Traceback (most recent call last):\n  File \"/usr/local/lib/python3.10/dist-packages/runpod/serverless/modules/rp_job.py\", line 182, in run_job\n    handler_return = handler(job)\n  File \"/app/rp_handler.py\", line 32, in handler\n    return asyncio.run(_handler_async(event))\n  File \"/usr/lib/python3.10/asyncio/runners.py\", line 33, in run\n    raise RuntimeError(\nRuntimeError: asyncio.run() cannot be called from a running event loop\n"